### PR TITLE
Remove pre-defined function in windows

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,6 +39,11 @@
 #include <zed/Camera.hpp>
 #include <zed/utils/GlobalDefine.hpp>
 
+#ifdef _WIN32
+#undef max
+#undef min
+#endif
+
 // PCL includes
 #include <pcl/common/common_headers.h>
 #include <pcl/visualization/pcl_visualizer.h>


### PR DESCRIPTION
This pr will resolve compile error in http://www.pcl-users.org/PCL-erros-in-my-project-td3515940.html
The error occurs when both pcl and windows have declared same function name.
